### PR TITLE
Add header identifier plugin

### DIFF
--- a/metalsmith.json
+++ b/metalsmith.json
@@ -16,6 +16,9 @@
       "gfm": true,
       "tables": true
     },
+    "metalsmith-headings-identifier": {
+      "linkTemplate": "<a href='#%s' class='linkable'><span>🏛</span></a> "
+    },
     "metalsmith-sass": {
       "outputDir": "stylesheets",
       "outputStyle": "expanded"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "metalsmith-broken-link-checker": "^0.1.8",
     "metalsmith-download": "0.0.1",
     "metalsmith-drafts": "0.0.1",
+    "metalsmith-headings-identifier": "0.0.11",
     "metalsmith-ignore": "^0.1.2",
     "metalsmith-layouts": "^1.0.0",
     "metalsmith-less": "^2.0.0",


### PR DESCRIPTION
set up https://github.com/majodev/metalsmith-headings-identifier so that we can more easily link doc.

(I was first considering using `¶` has anchor, but then decided to go for the building emoji.
see
<img width="825" alt="capture d ecran 2016-01-24 23 58 28" src="https://cloud.githubusercontent.com/assets/2601132/12539569/7bcd700a-c2f6-11e5-8545-62cb6b81cf04.png">