### PR TITLE
Typo in markdown caused broken link

### DIFF
--- a/src/pages/contribute/index.md
+++ b/src/pages/contribute/index.md
@@ -85,7 +85,7 @@ THE SOFTWARE.
 [Principles]: ./details/principles.html
 [Governance]: ./details/governance.html
 [Guidelines]: ./details/guidelines.html
-[Styleguide]: ./details/styleguide.html
+[Style guide]: ./details/styleguide.html
 [Code of Conduct]: ./details/code-of-conduct.html
 [Our tools]: ./details/our-tools.html
 [How we Work]: ./details/how-we-work.html


### PR DESCRIPTION
On the [contribute page](http://senecajs.org/contribute/) the style guide link is broken due to typo.