### PR TITLE
Replace obsolete rabbitmq-transport references

### DIFF
--- a/src/pages/getting-started/index.md
+++ b/src/pages/getting-started/index.md
@@ -1284,7 +1284,7 @@ Changes to one service do not affect the others. This is how microservices give 
 [shop-service.js]: https://github.com/senecajs/getting-started/blob/master/shop-service.js
 [math-pin-client.js]: https://github.com/senecajs/getting-started/blob/master/math-pin-client.js
 [app-all.js]: https://github.com/senecajs/getting-started/blob/master/app-all.js
-[message bus]: https://www.npmjs.com/package/seneca-rabbitmq-transport
+[message bus]: https://www.npmjs.com/package/seneca-amqp-transport
 [multiple clients]: https://www.npmjs.com/package/seneca-redis-transport
 [overlay network]: https://github.com/coreos/flannel
 [service discovery]: https://www.consul.io

--- a/src/pages/plugins/index.md
+++ b/src/pages/plugins/index.md
@@ -294,12 +294,12 @@ Seneca supports many different transports. Use the one that fits best with your 
 [seneca-transport-npm-downloads]: https://img.shields.io/npm/dm/seneca-transport.svg?style=flat-square
 [seneca-transport-npm-url]: https://npmjs.org/package/seneca-transport
 
-### [RabbitMQ](https://npmjs.com/package/seneca-rabbitmq-transport)
-[![version][seneca-rabbitmq-transport-npm-version]][seneca-rabbitmq-transport-npm-url]
-[![downloads][seneca-rabbitmq-transport-npm-downloads]][seneca-rabbitmq-transport-npm-url]
-[seneca-rabbitmq-transport-npm-version]: https://img.shields.io/npm/v/seneca-rabbitmq-transport.svg?style=flat-square
-[seneca-rabbitmq-transport-npm-downloads]: https://img.shields.io/npm/dm/seneca-rabbitmq-transport.svg?style=flat-square
-[seneca-rabbitmq-transport-npm-url]: https://npmjs.org/package/seneca-rabbitmq-transport
+### [AMQP](https://npmjs.com/package/seneca-amqp-transport)
+[![version][seneca-amqp-transport-npm-version]][seneca-amqp-transport-npm-url]
+[![downloads][seneca-amqp-transport-npm-downloads]][seneca-amqp-transport-npm-url]
+[seneca-amqp-transport-npm-version]: https://img.shields.io/npm/v/seneca-amqp-transport.svg?style=flat-square
+[seneca-amqp-transport-npm-downloads]: https://img.shields.io/npm/dm/seneca-amqp-transport.svg?style=flat-square
+[seneca-amqp-transport-npm-url]: https://npmjs.org/package/seneca-amqp-transport
 
 ### [Kafka](https://npmjs.com/package/seneca-kafka-transport)
 [![version][seneca-kafka-transport-npm-version]][seneca-kafka-transport-npm-url]
@@ -343,13 +343,6 @@ Seneca supports many different transports. Use the one that fits best with your 
 [seneca-activemq-transport-npm-version]: https://img.shields.io/npm/v/seneca-activemq-transport.svg?style=flat-square
 [seneca-activemq-transport-npm-downloads]: https://img.shields.io/npm/dm/seneca-activemq-transport.svg?style=flat-square
 [seneca-activemq-transport-npm-url]: https://npmjs.org/package/seneca-activemq-transport
-
-### [AMQP](https://npmjs.com/package/seneca-amqp-transport)
-[![version][seneca-amqp-transport-npm-version]][seneca-amqp-transport-npm-url]
-[![downloads][seneca-amqp-transport-npm-downloads]][seneca-amqp-transport-npm-url]
-[seneca-amqp-transport-npm-version]: https://img.shields.io/npm/v/seneca-amqp-transport.svg?style=flat-square
-[seneca-amqp-transport-npm-downloads]: https://img.shields.io/npm/dm/seneca-amqp-transport.svg?style=flat-square
-[seneca-amqp-transport-npm-url]: https://npmjs.org/package/seneca-amqp-transport
 
 ### [Redis Queue](https://npmjs.com/package/seneca-redis-queue-transport)
 [![version][seneca-redis-queue-transport-npm-version]][seneca-redis-queue-transport-npm-url]


### PR DESCRIPTION
Replaces [rabbitmq-transport](https://github.com/senecajs-labs/seneca-rabbitmq-transport) occurrences with [amqp-transport](https://github.com/senecajs/seneca-amqp-transport) references, to help users find the proper plugin and avoid leading them to [deprecated modules](https://github.com/senecajs-labs/seneca-rabbitmq-transport/issues/23).