### PR TITLE
Fix font-family for code blocks

### DIFF
--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -11,7 +11,7 @@ $ui-spacing-double: $ui-spacing*2;  /* 60px */
 // Font families
 $font-merriweather: Merriweather, Georgia, Times, serif;
 $font-open-sans: Open Sans, Helvetica, Arial, sans-serif;
-$font-monospaced: Menlo, Monaco, Consolas, monospaced;
+$font-monospaced: Menlo, Monaco, Consolas, monospace;
 
 // Font weight
 $font-weight-base: 400;


### PR DESCRIPTION
This was causing the website to show code blocks with normal text font, if the user didn't have any of the specific fonts. A bit annoying to the eye.