### PR TITLE
Issue 786: Remove broken link to old API page

### DIFF
--- a/src/pages/api/index.html.ejs
+++ b/src/pages/api/index.html.ejs
@@ -414,7 +414,7 @@ function X(name) {
 
 <div class="col-xs-12"><div class="box" style="margin-bottom:2rem">
 
-The API documentation is organized alphabetically into topics, subtopics and entries. Each entry contains a code example to show API usage
+The API documentation is organized alphabetically into topics, subtopics and entries. Each entry contains a code example to show API usage.
 
 </div></div>
 

--- a/src/pages/api/index.html.ejs
+++ b/src/pages/api/index.html.ejs
@@ -415,7 +415,6 @@ function X(name) {
 <div class="col-xs-12"><div class="box" style="margin-bottom:2rem">
 
 The API documentation is organized alphabetically into topics, subtopics and entries. Each entry contains a code example to show API usage
-(The <a href="old.html">old API documentation</a> is still available).
 
 </div></div>
 


### PR DESCRIPTION
Fixes https://github.com/senecajs/seneca/issues/786 by removing old outdated link.